### PR TITLE
Remove the percy-cli gem. Target Ruby 2.6.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
 ---
 
 AllCops:
-  TargetRubyVersion: 2.5.7
+  TargetRubyVersion: 2.6.0

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ source 'https://rubygems.org'
 #
 # This will help ensure the proper Jekyll version is running.
 # Happy Jekylling!
-# gem "jekyll", "~> 3.8.3"
+# gem 'jekyll', '~> 3.8.3'
 
 # This is the default theme for new Jekyll sites. You may change this to anything you like # rubocop:disable Metrics/LineLength
 # rubocop:enable Metrics/LineLength
@@ -30,7 +30,6 @@ end
 
 gem 'mdl'
 gem 'overcommit'
-gem 'percy-cli'
 gem 'rubocop', require: false
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,6 @@ GEM
       execjs
     coffee-script-source (1.11.1)
     colorator (1.1.0)
-    commander (4.4.7)
-      highline (~> 2.0.0)
     commonmarker (0.17.13)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.1.5)
@@ -27,7 +25,6 @@ GEM
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
     eventmachine (1.2.7-x64-mingw32)
-    excon (0.62.0)
     execjs (2.7.0)
     faraday (0.17.1)
       multipart-post (>= 1.2, < 3)
@@ -84,7 +81,6 @@ GEM
       octokit (~> 4.0)
       public_suffix (~> 3.0)
       typhoeus (~> 1.3)
-    highline (2.0.2)
     html-pipeline (2.12.2)
       activesupport (>= 2)
       nokogiri (>= 1.4)
@@ -232,15 +228,6 @@ GEM
       ast (~> 2.4.0)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    percy-cli (1.4.0)
-      addressable (~> 2)
-      commander (~> 4.3)
-      percy-client (~> 2.0)
-      thread (~> 0.2)
-    percy-client (2.0.3)
-      addressable
-      excon
-      faraday (>= 0.9)
     public_suffix (3.1.1)
     rainbow (3.0.0)
     rb-fsevent (0.10.3)
@@ -269,7 +256,6 @@ GEM
       faraday (> 0.8, < 2.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thread (0.2.2)
     tomlrb (1.2.8)
     typhoeus (1.3.1)
       ethon (>= 0.9.0)
@@ -292,7 +278,6 @@ DEPENDENCIES
   mdl
   minima (~> 2.5)
   overcommit
-  percy-cli
   rubocop
   tzinfo-data
 


### PR DESCRIPTION
fixes #160 