### PR TITLE
Add percy config file.

### DIFF
--- a/.percy.yml
+++ b/.percy.yml
@@ -1,0 +1,5 @@
+---
+
+version: 1
+snapshot:
+  widths: [1280]


### PR DESCRIPTION
 Set percy screen width to only 1280 to save snapshot bandwidth.